### PR TITLE
feat: extend supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Extract comment blocks from your files.
 
 * Simple to use
 * Extracts single- and multiline- comment blocks
-* Supports a small selection of [languages](./src/languages/languages.json)
+* Supports range of [languages](./src/languages/languages.json) covering the top 25 languages used in GitHub (+ more)
 
 <!-- Hee hee, hid a comment block in here -->
 

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -72,6 +72,12 @@
       "singleline": "//"
     },
     {
+      "name": "LUA",
+      "extensions": [ ".lua" ],
+      "multiline": { "start": "--[[", "end": "]]" },
+      "singleline": "--"
+    },
+    {
       "name": "Markdown",
       "extensions": [".md", ".mkd", ".mdwn", ".mdown", ".markdown"],
       "multiline": { "start": "<!--", "end": "-->" }

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -89,6 +89,12 @@
       "singleline": "#"
     },
     {
+      "name": "Objective-C",
+      "extensions": [ ".m", ".mm" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Plain Text",
       "filenames": [ ".gitignore", "CODEOWNERS" ],
       "singleline": "#"

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -18,6 +18,12 @@
       "singleline": "//"
     },
     {
+      "name": "CMake",
+      "extensions": [".cmake"],
+      "multiline": { "start": "#[[", "end": "]]" },
+      "singleline": "#"
+    },
+    {
       "name": "Javascript",
       "extensions": [ ".js" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -98,6 +98,12 @@
       "singleline": "#"
     },
     {
+      "name": "Ruby",
+      "extensions": [ ".rb" ],
+      "multiline": { "start": "=begin", "end": "=end" },
+      "singleline": "#"
+    },
+    {
       "name": "Swift",
       "extensions": [ ".swift" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -13,23 +13,13 @@
     },
     {
       "name": "C",
-      "extensions": [".c", ".h"],
+      "extensions": [ ".c", ".h" ],
       "multiline": { "start": "/*", "end": "*/" },
       "singleline": "//"
     },
     {
       "name": "C++",
-      "extensions": [
-        ".cpp",
-        ".hpp",
-        ".c++",
-        ".h++",
-        ".cc",
-        ".hh",
-        ".cxx",
-        ".hxx",
-        ".inl"
-      ],
+      "extensions": [ ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx" ],
       "multiline": { "start": "/*", "end": "*/" },
       "singleline": "//"
     },
@@ -44,6 +34,12 @@
       "extensions": [ ".cmake" ],
       "multiline": { "start": "#[[", "end": "]]" },
       "singleline": "#"
+    },
+    {
+      "name": "Dart",
+      "extensions": [ ".dart" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
     },
     {
       "name": "Go",

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -18,6 +18,22 @@
       "singleline": "//"
     },
     {
+      "name": "CPP",
+      "extensions": [
+        ".cpp",
+        ".hpp",
+        ".c++",
+        ".h++",
+        ".cc",
+        ".hh",
+        ".cxx",
+        ".hxx",
+        ".inl"
+      ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "CMake",
       "extensions": [".cmake"],
       "multiline": { "start": "#[[", "end": "]]" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -1,6 +1,11 @@
 {
   "languages": [
     {
+      "name": "AWK",
+      "extensions": [".awk"],
+      "singleline":"#"
+    },
+    {
       "name": "Javascript",
       "extensions": [ ".js" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -41,9 +41,15 @@
     },
     {
       "name": "CMake",
-      "extensions": [".cmake"],
+      "extensions": [ ".cmake" ],
       "multiline": { "start": "#[[", "end": "]]" },
       "singleline": "#"
+    },
+    {
+      "name": "Groovy",
+      "extensions": [ ".groovy", ".gvy", ".gy", ".gsh" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
     },
     {
       "name": "Javascript",

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -104,6 +104,11 @@
       "singleline": "#"
     },
     {
+      "name": "Shell",
+      "extensions": [ ".sh" ],
+      "singleline": "#"
+    },
+    {
       "name": "Swift",
       "extensions": [ ".swift" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -81,6 +81,12 @@
       "multiline": { "start": "<!--", "end": "-->" }
     },
     {
+      "name": "Nix",
+      "extensions": [ ".nix" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "#"
+    },
+    {
       "name": "Plain Text",
       "filenames": [ ".gitignore", "CODEOWNERS" ],
       "singleline": "#"

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -80,6 +80,12 @@
       "singleline": "#"
     },
     {
+      "name": "Python",
+      "extensions": [ ".py" ],
+      "multiline": { "start": "\"\"\"", "end": "\"\"\"" },
+      "singleline": "#"
+    },
+    {
       "name": "Typescript",
       "extensions": [ ".ts" ],
       "multiline": { "start": "/*", "end": "*/"},

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -1,6 +1,12 @@
 {
   "languages": [
     {
+      "name": "Asciidoc",
+      "extensions": [".asciidoc", ".adoc", ".asc"],
+      "multiline": { "start": "////", "end": "////" },
+      "singleline": "//"
+    },
+    {
       "name": "AWK",
       "extensions": [".awk"],
       "singleline":"#"

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -110,6 +110,12 @@
       "singleline": "#"
     },
     {
+      "name": "Rust",
+      "extensions": [ ".rs" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Shell",
       "extensions": [ ".sh" ],
       "singleline": "#"

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -94,6 +94,12 @@
       "singleline": "#"
     },
     {
+      "name": "Perl",
+      "extensions": [ ".pl", ".pm" ],
+      "multiline": { "start": "=pod", "end": "=cut" },
+      "singleline": "#"
+    },
+    {
       "name": "PHP",
       "extensions": [ ".php" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -46,6 +46,12 @@
       "singleline": "#"
     },
     {
+      "name": "Go",
+      "extensions": [ ".go" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Groovy",
       "extensions": [ ".groovy", ".gvy", ".gy", ".gsh" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -12,6 +12,12 @@
       "singleline":"#"
     },
     {
+      "name": "C",
+      "extensions": [".c", ".h"],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Javascript",
       "extensions": [ ".js" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -86,6 +86,12 @@
       "singleline": "#"
     },
     {
+      "name": "PHP",
+      "extensions": [ ".php" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Python",
       "extensions": [ ".py" ],
       "multiline": { "start": "\"\"\"", "end": "\"\"\"" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -86,6 +86,12 @@
       "singleline": "#"
     },
     {
+      "name": "Swift",
+      "extensions": [ ".swift" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Typescript",
       "extensions": [ ".ts" ],
       "multiline": { "start": "/*", "end": "*/"},

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -64,6 +64,12 @@
       "singleline": "//"
     },
     {
+      "name": "Kotlin",
+      "extensions": [ ".kt", ".kts" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Markdown",
       "extensions": [".md", ".mkd", ".mdwn", ".mdown", ".markdown"],
       "multiline": { "start": "<!--", "end": "-->" }

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -52,6 +52,12 @@
       "singleline": "//"
     },
     {
+      "name": "Java",
+      "extensions": [ ".java" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Javascript",
       "extensions": [ ".js" ],
       "multiline": { "start": "/*", "end": "*/" },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -18,7 +18,7 @@
       "singleline": "//"
     },
     {
-      "name": "CPP",
+      "name": "C++",
       "extensions": [
         ".cpp",
         ".hpp",
@@ -30,6 +30,12 @@
         ".hxx",
         ".inl"
       ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
+      "name": "C#",
+      "extensions": [ ".cs" ],
       "multiline": { "start": "/*", "end": "*/" },
       "singleline": "//"
     },

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -116,6 +116,12 @@
       "singleline": "//"
     },
     {
+      "name": "Scala",
+      "extensions": [ ".scala" ],
+      "multiline": { "start": "/*", "end": "*/" },
+      "singleline": "//"
+    },
+    {
       "name": "Shell",
       "extensions": [ ".sh" ],
       "singleline": "#"


### PR DESCRIPTION
This commit introduces support for the top 25 languages used in GitHub in between Q1 and Q2 of 2023.