### PR TITLE
feat: allow overriding of default language configurations

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -52,31 +52,20 @@ export function getLanguageToken(file: string): ILanguageTokens {
 export function getLanguage(file: string): ILanguage {
   const matches = getLanguageMatches(file);
   if (matches.length === 0) throw new Error(`Language for file '${file}' not found`);
-  if (matches.length > 1) throw new Error(`Multiple languages for file '${file}' found`);
   const language = matches[0];
 
   return language;
 }
 
 /**
- * Extends the list of supported languages with the provided language
+ * Extends the list of supported languages with the provided language.
+ * NOTE: Adding any new language including overlapping filenames or extensions,
+ * will override any previously existing language (incl. defaults).
+ *
  * @param language The language to add
  */
 export function addLanguage(language: ILanguage): void {
-  // Validate for duplication of extensions
-  for (const extension of language.extensions ?? []) {
-    if (!extension.startsWith(".")) {
-      throw new Error(`Extension '${extension}' does not start with a period`);
-    }
-    isSupported(`test${extension}`);
-  }
-
-  // Validate for duplication of filenames
-  for (const filename of language.filenames ?? []) {
-    isSupported(filename);
-  }
-
-  LANGUAGES.push(language);
+  LANGUAGES.unshift(language);
 }
 
 /**
@@ -86,8 +75,10 @@ export function addLanguage(language: ILanguage): void {
  */
 export function isSupported(file: string): boolean {
   try {
-    return getLanguage(file) !== undefined;
+    getLanguage(file);
   } catch (error) {
     return false;
   }
+
+  return true;
 }

--- a/src/languages/languages.json
+++ b/src/languages/languages.json
@@ -137,13 +137,13 @@
     },
     {
       "name": "Make",
-      "extensions": ".mk",
+      "extensions": [ ".mk" ],
       "filenames": ["GNUmakefile", "makefile", "Makefile"],
       "singleline": "#"
     },
     {
       "name": "Mako",
-      "extensions": ".mako",
+      "extensions": [ ".mako" ],
       "multiline": { "start": "<%doc>", "end": "</%doc>" },
       "singleline": "##"
     },

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -3,7 +3,9 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: MIT
 */
 
+import { ILanguage } from "../src";
 import { isSupported, addLanguage, getLanguageToken } from "../src/languages";
+import { languages } from "../src/languages/languages.json";
 
 describe("Languages", () => {
   const testData = [
@@ -41,6 +43,34 @@ describe("Languages", () => {
 
   it.each(testData)("$description", ({ file, isSupported: expectations }) => {
     expect(isSupported(file as string)).toBe(expectations);
+  });
+});
+
+describe("Check for duplication in languages", () => {
+  test("Check for filename duplications", () => {
+    const filenames = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const language of languages) {
+      for (const filename of language.filenames ?? []) {
+        if (filenames.has(filename)) duplicates.add(filename);
+        else filenames.add(filename);
+      }
+    }
+
+    expect(duplicates).toEqual(new Set<string>());
+  });
+
+  test("Check for extension duplications", () => {
+    const extensions = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const language of languages) {
+      for (const extension of language.extensions ?? []) {
+        if (extensions.has(extension)) duplicates.add(extension);
+        else extensions.add(extension);
+      }
+    }
+
+    expect(duplicates).toEqual(new Set<string>());
   });
 });
 

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 */
 
 import { ILanguage } from "../src";
-import { isSupported, addLanguage, getLanguageToken } from "../src/languages";
+import { isSupported, addLanguage, getLanguageToken, getLanguage } from "../src/languages";
 import { languages } from "../src/languages/languages.json";
 
 describe("Languages", () => {
@@ -87,13 +87,15 @@ describe("Add custom language", () => {
   });
 
   test("Add overlapping language", () => {
-    addLanguage({
+    const newLanguage = {
       name: "Overlapping Test",
       extensions: [".yml"],
-      singleline: "//",
-    });
+      singleline: "{%",
+    }
 
-    expect(isSupported("test.yml")).toBe(false);
-    expect(() => getLanguageToken("test.yml")).toThrow();
+    addLanguage(newLanguage);
+
+    expect(isSupported("test.yml")).toBe(true);
+    expect(getLanguage("test.yml")).toBe(newLanguage)
   });
 });


### PR DESCRIPTION
It is now possible to add/override new languages using overlapping
`filenames` and/or `extensions` values. This is particularly useful
when you are using a different standard for certain files (i.e.
plain text).

You can add/override a language as follows:

```typescript
import { addLanguage } from "@dev-build-deploy/comment-it";

addLanguage({
  name: "Custom YAML configuration",
  extensions: [".yaml"],
  singleline: "{%",
});
```