### PR TITLE
feat: add support for grouping sequential singleline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ const file = "README.md";
 
 // Check if the file is supported by CommentIt
 if (isSupported(file)) {
+  const config = {
+    /** Only consider comments in the first ..n lines */
+    maxLines: 20,
+    /** Group sequential singleline comments into a comment block */
+    groupSingleline: true,
+  };
+
   // Retrieve each comment block using an iterator
-  for await (const comment of extractComments(file), /* OPTIONAL */ { maxLines: 20 }) {
-    console.log(JSON.stringify(comment, null, 2))
+  for await (const comment of extractComments(file), /* OPTIONAL */ config) {
+    console.log(JSON.stringify(comment, null, 2));
   }
 }
 ```
@@ -39,10 +46,30 @@ This will result in [IComment](#comment-interface) objects, considering the abov
   "type": "multiline",
   "format": { "start": "<!--", "end": "-->"},
   "contents": [
-    { "line":  1, "column": { "start": 0, "end":  4 }, "value": "<!--" },
-    { "line":  2, "column": { "start": 0, "end": 64 }, "value": "SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>" },
-    { "line":  3, "column": { "start": 0, "end": 41 }, "value": "SPDX-License-Identifier: GPL-3.0-or-later" },
-    { "line":  4, "column": { "start": 0, "end":  3 }, "value": "-->" }
+    {
+      "line":   1,
+      "column": { "start": 0, "end":  4 },
+      "raw":    "<!--",
+      "value":  ""
+    },
+    {
+      "line":   2,
+      "column": { "start": 0, "end": 64 },
+      "raw":    "SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>",
+      "value":  "SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>"
+    },
+    {
+      "line":   3,
+      "column": { "start": 0, "end": 41 },
+      "raw":    "SPDX-License-Identifier: MIT",
+      "value":  "SPDX-License-Identifier: MIT"
+    },
+    {
+      "line":  4,
+      "column": { "start": 0, "end":  3 },
+      "raw": "-->",
+      "value": ""
+    }
   ]
 }
 
@@ -50,11 +77,45 @@ This will result in [IComment](#comment-interface) objects, considering the abov
   "type": "multiline",
   "format": { "start": "<!--", "end": "-->" },
   "contents": [
-    { "line": 16, "column": { "start": 0, "end": 45 }, "value": "<!-- Hee hee, hid a comment block in here -->" }
+    {
+      "line": 16,
+      "column": { "start": 0, "end": 45 },
+      "raw": "<!-- Hee hee, hid a comment block in here -->",
+      "value": "Hee hee, hid a comment block in here"
+    }
   ]
 }
 ```
 <!-- REUSE-IgnoreEnd -->
+
+## Custom Language(s)
+
+You can use the `addLanguage()` function to add new languages to the validation set:
+
+```typescript
+import { addLanguage } from "@dev-build-deploy/comment-it";
+
+addLanguage({
+  name: "Pingu Language",
+  filenames: [".pingu"],
+  extensions: [".noot"],
+  singleline: "{%NOOTNOOT%}",
+});
+```
+
+The same function can also be used to override a (default) configuration. For example,
+the following code snippet replaces the comment prefix from `;` to `#` for files with
+the`.ini` file extension:
+
+```typescript
+import { addLanguage } from "@dev-build-deploy/comment-it";
+
+addLanguage({
+  name: "Custom ini",
+  extensions: [".ini"],
+  singleline: "#",
+});
+```
 
 ## Comment Interface
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,4 +121,6 @@ export interface ILanguageTokens {
 export interface IExtractorOptions {
   /** The maximum amount of lines to extract comments from */
   maxLines?: number;
+  /** Group multiple singleline comments into a comment block */
+  groupSingleline?: boolean;
 }

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -91,11 +91,11 @@ describe("Add custom language", () => {
       name: "Overlapping Test",
       extensions: [".yml"],
       singleline: "{%",
-    }
+    };
 
     addLanguage(newLanguage);
 
     expect(isSupported("test.yml")).toBe(true);
-    expect(getLanguage("test.yml")).toBe(newLanguage)
+    expect(getLanguage("test.yml")).toBe(newLanguage);
   });
 });


### PR DESCRIPTION
This commit add the option `groupSingleline` to `IExtractorOptions` and can be used to group multiple single line comments into a single comment block, i.e.:

```
// Block A, Line 1
// Block A, Line 2

// Block B, Line 1
  // Block C, Line 1
```

NOTE: Each singleline entry must start at the same column no as the previous one